### PR TITLE
찜 예외처리 수정 & 지도페이지 디자인 수정

### DIFF
--- a/App.js
+++ b/App.js
@@ -56,7 +56,7 @@ const App = () => {
         setLoaded(true);
       });
     } catch (error) {
-      console.log(error);
+      console.log("폰트 로딩 실패" + error);
     }
   };
 

--- a/reducer/index.js
+++ b/reducer/index.js
@@ -89,13 +89,14 @@ export const jjimCheck = (boolean) => ({
   boolean,
 });
 
-export const addJjim = (store, storeList) => ({
+export const addJjim = (storeList, store, category) => ({
   type: ADD_JJIM,
   storeList,
   store,
+  category,
 });
 
-export const deleteJjim = (store, storeList) => ({
+export const deleteJjim = (storeList, store) => ({
   type: DELETE_JJIM,
   storeList,
   store,
@@ -155,7 +156,7 @@ const reducer = (state = initState, action) => {
       };
     case ADD_JJIM:
       const jjimList = [...action.storeList];
-      jjimList.push({ store_name: action.store });
+      jjimList.push({ store_name: action.store, l_category: action.category });
       return {
         ...state,
         jjimStore: jjimList,

--- a/src/Components/HeaderBar/index.js
+++ b/src/Components/HeaderBar/index.js
@@ -55,8 +55,8 @@ const HeaderBar = (props) => {
           .then((res) => {
             res.data.success
               ? (dispatch(jjimCheck(false)),
-                dispatch(deleteJjim(storeName, jjimList)),
-                console.log("삭제 성공"))
+                dispatch(deleteJjim(jjimList, storeName)),
+                console.log("찜 삭제 성공"))
               : console.log("찜 삭제 실패");
           })
           .catch((err) => {
@@ -78,7 +78,7 @@ const HeaderBar = (props) => {
           .then((res) => {
             res.data.success
               ? (dispatch(jjimCheck(true)),
-                dispatch(addJjim(storeName, jjimList)),
+                dispatch(addJjim(jjimList, storeName, res.data.l_category)),
                 console.log("찜추가 성공"))
               : console.log("찜 추가 실패");
           })

--- a/src/Screens/Home/index.js
+++ b/src/Screens/Home/index.js
@@ -108,6 +108,7 @@ const Home = ({ navigation }) => {
   axios.defaults.baseURL = url;
 
   const [categoryList, setCategoryList] = useState([]);
+  const [jjimList, setJjimList] = useState([]);
 
   const TOKEN_KEY = "@userKey";
 
@@ -141,15 +142,17 @@ const Home = ({ navigation }) => {
         },
       })
       .then((res) => {
-        console.log("찜 목록: " + res.data.list);
+        console.log("찜 목록: " + JSON.stringify(res.data.list));
+        if (res.data.list !== undefined) setJjimList(res.data.list);
         dispatch(restoreJjimStore(res.data.list));
       })
-      .catch((error) => {
-        console.log(error);
-      });
+      .catch((err) => console.log("찜 목록 못 받아옴~~ " + err));
   }, []);
 
   const jjimjjim = useSelector((state) => state.jjimStore);
+  useEffect(() => {
+    if (jjimjjim !== null) setJjimList(jjimjjim);
+  }, [jjimjjim]);
 
   return (
     <SafeAreaView
@@ -202,12 +205,12 @@ const Home = ({ navigation }) => {
               showsHorizontalScrollIndicator={false}
               contentContainerStyle={{ marginTop: 15, flexDirection: "row" }}
             >
-              {jjimjjim[0] == undefined ? (
+              {jjimList.length === 0 ? (
                 <SC.NoJjimWrap>
                   <Text>찜한 가게가 없어요~</Text>
                 </SC.NoJjimWrap>
               ) : (
-                jjimjjim.slice(0, 5).map((item, index) => {
+                jjimList.slice(0, 5).map((item, index) => {
                   return (
                     <JjimEle
                       key={index}
@@ -219,7 +222,7 @@ const Home = ({ navigation }) => {
                   );
                 })
               )}
-              {jjimjjim.length > 5 ? (
+              {jjimList.length > 5 ? (
                 <SC.JjimEleWrap
                   activeOpacity={0.8}
                   onPress={() => navigation.navigate("JjimPage")}

--- a/src/Screens/Jjim/index.js
+++ b/src/Screens/Jjim/index.js
@@ -17,11 +17,6 @@ const StatusBarHeight = StatusBar.currentHeight;
 const SC = {
   Container: styled.View`
     background-color: #fff;
-    ${Platform.OS === "android"
-      ? css`
-          padding-top: ${StatusBarHeight}px;
-        `
-      : undefined}
   `,
   JjimContainer: styled.View`
     height: 100%;
@@ -30,7 +25,7 @@ const SC = {
 };
 const JjimPage = ({ navigation }) => {
   const dispatch = useDispatch();
-  const JjimList = useSelector((state) => state.jjimStore);
+  const jjimList = useSelector((state) => state.jjimStore);
 
   return (
     <SafeAreaView
@@ -48,7 +43,7 @@ const JjimPage = ({ navigation }) => {
         />
         <SC.JjimContainer>
           <ScrollView>
-            {JjimList.map((item, index) => {
+            {jjimList.map((item, index) => {
               return (
                 <TouchableOpacity
                   key={index}

--- a/src/Screens/Map/MiddleCatBtn/index.js
+++ b/src/Screens/Map/MiddleCatBtn/index.js
@@ -8,6 +8,7 @@ import {
   Dimensions,
   Text,
   View,
+  StyleSheet,
 } from "react-native";
 import styled, { css } from "styled-components/native";
 import { useSelector, useDispatch } from "react-redux";
@@ -15,10 +16,11 @@ import { restoreCurMidCat } from "../../../../reducer/index";
 
 const SC = {
   Wrap: styled.View`
-    padding: 4px 10px;
-    border: 1px solid black;
-    border-radius: 20px;
+    padding: 6px 10px;
+    // border: 1px solid black;
+    border-radius: 15px;
     margin-right: 5px;
+    background-color: #fff;
   `,
 };
 
@@ -26,7 +28,7 @@ const MiddleCatBtn = (props) => {
   const dispatch = useDispatch();
 
   return (
-    <SC.Wrap>
+    <SC.Wrap style={styles.shadow}>
       <Text
         onPress={() => {
           dispatch(restoreCurMidCat(props.name));
@@ -39,3 +41,22 @@ const MiddleCatBtn = (props) => {
 };
 
 export default MiddleCatBtn;
+
+const styles = StyleSheet.create({
+  shadow: {
+    ...Platform.select({
+      ios: {
+        shadowColor: "#000",
+        shadowOffset: {
+          width: 0,
+          height: 2,
+        },
+        shadowOpacity: 0.25,
+        shadowRadius: 3.84,
+      },
+      android: {
+        elevation: 3,
+      },
+    }),
+  },
+});

--- a/src/Screens/Map/MiddleCatBtnWrap/index.js
+++ b/src/Screens/Map/MiddleCatBtnWrap/index.js
@@ -1,15 +1,27 @@
 import React, { useState } from "react";
-import { ScrollView } from "react-native";
+import { ScrollView, StatusBar, Dimensions } from "react-native";
 import MiddleCatBtn from "../MiddleCatBtn/index";
+import styled, { css } from "styled-components/native";
+
+const StatusBarHeight = StatusBar.currentHeight;
+const { width, height } = Dimensions.get("window");
+
+const SC = {
+  Container: styled.ScrollView`
+    position: absolute;
+    top: ${StatusBarHeight + height * 0.03}px;
+    z-index: 5;
+  `,
+};
 
 const MiddleCatBtnWrap = (props) => {
   const category = props.cat;
   return (
-    <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+    <SC.Container horizontal showsHorizontalScrollIndicator={false}>
       {category.map((item, index) => {
         return <MiddleCatBtn key={index} name={item}></MiddleCatBtn>;
       })}
-    </ScrollView>
+    </SC.Container>
   );
 };
 

--- a/src/Screens/Map/index.js
+++ b/src/Screens/Map/index.js
@@ -7,6 +7,8 @@ import {
   Platform,
   Text,
   View,
+  Dimensions,
+  StyleSheet,
 } from "react-native";
 import styled, { css } from "styled-components/native";
 import { FontAwesome } from "@expo/vector-icons";
@@ -19,27 +21,43 @@ import MiddleCatBtnWrap from "./MiddleCatBtnWrap/index";
 import { restoreCurMidCat, restoreCurStore } from "../../../reducer/index";
 
 const StatusBarHeight = StatusBar.currentHeight;
+const { width, height } = Dimensions.get("window");
+
 const SC = {
   Container: styled.View`
     background-color: #fff;
     flex: 1;
     ${Platform.OS === "android"
       ? css`
-          padding-top: ${StatusBarHeight + 15}px;
+          padding-top: ${StatusBarHeight}px;
         `
       : undefined}
   `,
   Category: styled.View`
-    height: 25px;
     background-color: yellow;
     align-items: center;
     justify-content: space-between;
-    margin-right: 15px;
-    padding: 4px 10px;
+    margin-right: 5px;
+    padding: 6px 10px;
+    border-radius: 15px;
   `,
   LargeCatWrap: styled.View`
+    position: absolute;
+    top: ${StatusBarHeight + height * 0.06}px;
+    z-index: 5;
     flex-direction: row;
     justify-content: space-between;
+  `,
+  ShopWrap: styled.TouchableOpacity`
+    position: absolute;
+    bottom: 0;
+    z-index: 5;
+    width: 100%;
+    height: 100px;
+    background-color: pink;
+    // border-top-left-radius: 30px;
+    // border-top-right-radius: 30px;
+    padding: 10px;
   `,
 };
 
@@ -51,6 +69,7 @@ const Map = ({ navigation, route }) => {
   const clickedMiddle = useSelector((state) => state.curMidCat);
   const largeCat = useSelector((state) => state.largeCatList);
   const middleCat = useSelector((state) => state.midCatList);
+  const mainColor = useSelector((state) => state.mainColor);
 
   const [initialRegion, setInitialRegion] = useState({
     latitude: 37.4513546060566,
@@ -62,6 +81,8 @@ const Map = ({ navigation, route }) => {
   const [clickedCat, setClickedCat] = useState("");
   const [midCatList, setMidCatList] = useState({});
   const [middleCatLocation, setMiddleCatLocation] = useState([]);
+  const [clickShop, setClickShop] = useState(false);
+  const [clickedShopInfo, setClickedShopInfo] = useState();
 
   useEffect(() => {
     if (clickedCat === "술집") {
@@ -99,11 +120,17 @@ const Map = ({ navigation, route }) => {
       }}
     >
       <SC.Container>
+        <HeaderBar
+          left="arrow"
+          title="지도"
+          right="magni"
+          navigation={navigation}
+        ></HeaderBar>
         <SC.LargeCatWrap>
           <ScrollView horizontal showsHorizontalScrollIndicator={false}>
             {largeCat.map((item, index) => {
               return (
-                <SC.Category key={index}>
+                <SC.Category key={index} style={styles.shadow}>
                   <Text onPress={() => MiddleCatListAPI(item.name)}>
                     {item.name}
                   </Text>
@@ -141,9 +168,12 @@ const Map = ({ navigation, route }) => {
                     latitude: item.latitude,
                     longitude: item.longitude,
                   }}
-                  title={item.store_name}
+                  // title={item.store_name}
+                  onPress={() => {
+                    setClickShop(true), setClickedShopInfo(item.store_name);
+                  }}
                 >
-                  <MapView.Callout
+                  {/* <MapView.Callout
                     onPress={() => {
                       navigation.navigate("StorePage", {
                         key: item.store_name,
@@ -154,16 +184,49 @@ const Map = ({ navigation, route }) => {
                     <TouchableOpacity>
                       <Text>{item.store_name}</Text>
                     </TouchableOpacity>
-                  </MapView.Callout>
-                  {/* <FontAwesome name="map-marker" size={40} color="#B12A5B" /> */}
+                  </MapView.Callout> */}
+                  <FontAwesome name="map-marker" size={30} color={mainColor} />
                 </MapView.Marker>
               </>
             );
           })}
         </MapView>
+        {clickShop ? (
+          <SC.ShopWrap
+            onPress={() => {
+              navigation.navigate("StorePage", {
+                key: clickedShopInfo,
+              });
+              dispatch(restoreCurStore(clickedShopInfo));
+            }}
+          >
+            <Text>{clickedShopInfo}</Text>
+          </SC.ShopWrap>
+        ) : (
+          <></>
+        )}
       </SC.Container>
     </SafeAreaView>
   );
 };
 
 export default Map;
+
+const styles = StyleSheet.create({
+  shadow: {
+    ...Platform.select({
+      ios: {
+        shadowColor: "#000",
+        shadowOffset: {
+          width: 0,
+          height: 2,
+        },
+        shadowOpacity: 0.25,
+        shadowRadius: 3.84,
+      },
+      android: {
+        elevation: 3,
+      },
+    }),
+  },
+});


### PR DESCRIPTION
## 1. Home 화면에서 찜 목록 보이는 방식
변경 전: 찜 리스트 axios로 받아서 dispatch -> redux에 있는 찜한 가게 리스트 가져와서 렌더링
=> 문제:  dispatch 비동기 문제로 첫 렌더링 때 redux에서 찜한 가게 리스트를 가져오지 못함
변경 후: 찜 리스트 axios로 받아서 dispatch & useState로 리스트 저장하고 렌더링 -> redux에 있는 찜한 가게 리스트 가져와서 useEffect의 dependency에 넣고 변화 있을 때마다 setState

## 2. 지도페이지 디자인 수정
- 대분류 & 중분류 버튼들을 지도 위에 뜨게 함
- 변경 전: 핀 클릭시 원래 callout으로 가게이름 뜨고 가게이름 클릭하면 해당 가게 페이지로 이동
- 변경 후: 핀 클릭 시 지도 위에서는 변화 없고 제일 하단에 가게 정보 뜸 (클릭하면 해당 가게 페이지로 이동)

---------------
### 고민해 볼 것들
- 지도 페이지 핀 클릭했을 때 보여줄 가게 세부 정보들 & 디자인
- 핀 클릭했다가 지도 빈 부분 클릭하면 밑에 떴던 가게 정보가 사라져야 하는데 처리 못함 (방법 고민해 봐야 함...)
- 찜 페이지에서 보여줄 가게 세부 정보들 & 디자인
 